### PR TITLE
Build for non x86_64 hosts.

### DIFF
--- a/dlmacros.h
+++ b/dlmacros.h
@@ -211,7 +211,9 @@
 #else
 static inline void _mm_pause(void)
 {
+#ifdef __x86_64__
   __asm__ ( "pause;" );
+#endif
 }
 #endif
 


### PR DESCRIPTION
_mm_pause() in dlmacros.h include pause instruction.
But the instruction only exists on x86_64.
This PR ignore th instruction when non x86_64 hosts.